### PR TITLE
fix kong support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed kong support.
+
 ## [0.2.0] - 2026-04-15
 
 ### Added

--- a/envoy-loadtesting/k6/test-scenario.js
+++ b/envoy-loadtesting/k6/test-scenario.js
@@ -66,6 +66,8 @@ const SCENARIO_CONFIG = {
 // Stagger scenario start times to avoid synchronized request bursts; Envoy starts immediately, nginx starts after Envoy's duration
 const nginxStartTime = `${SCENARIO_DURATION_SECONDS + WAIT_BETWEEN_SCENARIOS}s`;
 
+const kongStartTime = `${SCENARIO_DURATION_SECONDS + WAIT_BETWEEN_SCENARIOS + parseInt(nginxStartTime)}s`;
+
 export const options = {
   scenarios: {
     envoy_simulation: {
@@ -77,6 +79,11 @@ export const options = {
       ...SCENARIO_CONFIG,
       exec: "nginxScenario",
       startTime: nginxStartTime,
+    },
+    kong_simulation: {
+      ...SCENARIO_CONFIG,
+      exec: "kongScenario",
+      startTime: kongStartTime,
     },
   },
   thresholds: {
@@ -90,12 +97,18 @@ export const options = {
       `p(95)<${SLO_P95_LATENCY_MS}`,
       `p(99)<${SLO_P99_LATENCY_MS}`,
     ],
+    "http_req_duration{scenario:kong_simulation}": [
+      `p(95)<${SLO_P95_LATENCY_MS}`,
+      `p(99)<${SLO_P99_LATENCY_MS}`,
+    ],
     // Error rate: default < 0.1% (issue recommends < 0.1% steady state).
     "http_req_failed{scenario:envoy_simulation}": [`rate<${SLO_ERROR_RATE}`],
     "http_req_failed{scenario:nginx_simulation}": [`rate<${SLO_ERROR_RATE}`],
+    "http_req_failed{scenario:kong_simulation}": [`rate<${SLO_ERROR_RATE}`],
     // HTTP/2 check applies to Envoy; scoped to avoid tainting nginx checks rate.
     "checks{scenario:envoy_simulation}": [`rate>${SLO_CHECKS_RATE}`],
     "checks{scenario:nginx_simulation}": [`rate>${SLO_CHECKS_RATE}`],
+    "checks{scenario:kong_simulation}": [`rate>${SLO_CHECKS_RATE}`],
   },
 };
 

--- a/envoy-loadtesting/wc-deployment/values/kong.yaml
+++ b/envoy-loadtesting/wc-deployment/values/kong.yaml
@@ -11,3 +11,18 @@ proxy:
   annotations:
     giantswarm.io/external-dns: managed
     external-dns.alpha.kubernetes.io/hostname: kong-ingress.${WC}.${BASE_DOMAIN}
+extraObjects:
+  - apiVersion: configuration.konghq.com/v1
+    kind: KongClusterPlugin
+    metadata:
+      name: prometheus
+      annotations:
+        kubernetes.io/ingress.class: kong
+      labels:
+        global: "true"
+    plugin: prometheus
+    config:
+      status_code_metrics: true
+      latency_metrics: true
+      bandwidth_metrics: true
+      upstream_health_metrics: true


### PR DESCRIPTION
This PR fixes the testRun file to make sure the Kong scenario is also triggered and add the necessary KongClusterPlugin to generate metrics necessary for the dashboard from this PR: https://github.com/giantswarm/dashboards/pull/865

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
