### PR TITLE
update kong to support gateway api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update kong setup to make it work with Gateway API.
+- Add kong app and user values configmap to kustomization.
 
 ## [0.2.1] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update kong setup to make it work with Gateway API.
+
 ## [0.2.1] - 2026-04-16
 
 ### Fixed

--- a/envoy-loadtesting/kustomization.yaml
+++ b/envoy-loadtesting/kustomization.yaml
@@ -276,6 +276,20 @@ replacements:
     options:
       delimiter: '-'
       index: 0
+  # --- kong-app App ---
+  - select:
+      kind: App
+      name: CLUSTER-kong-app
+    fieldPaths:
+    - metadata.name
+    - metadata.labels.[giantswarm.io/cluster]
+    - spec.config.configMap.name
+    - spec.kubeConfig.context.name
+    - spec.kubeConfig.secret.name
+    - spec.userConfig.configMap.name
+    options:
+      delimiter: '-'
+      index: 0
   # --- microservices-demo-app OCIRepository ---
   - select:
       kind: OCIRepository
@@ -327,6 +341,14 @@ replacements:
   - select:
       kind: ConfigMap
       name: CLUSTER-ingress-nginx-user-values
+    fieldPaths:
+    - metadata.name
+    options:
+      delimiter: '-'
+      index: 0
+  - select:
+      kind: ConfigMap
+      name: CLUSTER-kong-user-values
     fieldPaths:
     - metadata.name
     options:

--- a/envoy-loadtesting/wc-deployment/values/kong.yaml
+++ b/envoy-loadtesting/wc-deployment/values/kong.yaml
@@ -1,12 +1,13 @@
 ingressController:
   enabled: true
-  createIngressClass: true
+  createIngressClass: false
   watchNamespaces:
     - loadtesting
     - kong
   rbac:
     gatewayAPI:
-      enabled: false
+      enabled: true
+  ingressClass: none  # Prevents KIC from reconciling Ingress resources; Gateway API only
 proxy:
   annotations:
     giantswarm.io/external-dns: managed
@@ -26,3 +27,23 @@ extraObjects:
       latency_metrics: true
       bandwidth_metrics: true
       upstream_health_metrics: true
+  - apiVersion: rbac.authorization.k8s.io/v1                                                                                                                                          
+    kind: ClusterRole                                                                                                                                                                 
+    metadata:                                                                                                                                                                         
+      name: kong-app-kong-app-ingressclass-reader                                                                                                                                     
+    rules:                                                                                                                                                                            
+      - apiGroups: ["networking.k8s.io"]                                                                                                                                              
+        resources: ["ingressclasses"]                                                                                                                                                 
+        verbs: ["get", "list", "watch"]                                                                                                                                               
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding                
+    metadata:                               
+      name: kong-app-kong-app-ingressclass-reader                                         
+    roleRef:                                                                                                                                                                          
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole                                                                                                                                                               
+      name: kong-app-kong-app-ingressclass-reader
+    subjects:                               
+      - kind: ServiceAccount
+        name: kong-app-kong-app
+        namespace: kong

--- a/helm/microservices-demo-app/templates/kong/certificate.yaml
+++ b/helm/microservices-demo-app/templates/kong/certificate.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - '*.{{ .Release.Namespace }}.{{ .Values.kong.base }}'
+  - '{{ .Values.kong.host }}.{{ .Release.Namespace }}.{{ .Values.kong.base }}'
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/helm/microservices-demo-app/templates/kong/dnsendpoint.yaml
+++ b/helm/microservices-demo-app/templates/kong/dnsendpoint.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.frontend.create }}
 {{- if .Values.kong.enabled }}
-{{ range $i := until (.Values.kong.number | int) }}
 ---
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
@@ -12,15 +11,14 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     application.giantswarm.io/team: cabbage
-  name: {{ $.Values.frontend.name }}-kong-{{ $i }}
-  namespace: {{ $.Release.Namespace }}
+  name: {{ .Values.frontend.name }}-kong
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
-  - dnsName: {{ $.Values.kong.host }}-{{ $i }}.{{ $.Release.Namespace }}.{{ $.Values.kong.base }}
+  - dnsName: {{ .Values.kong.host }}.{{ .Release.Namespace }}.{{ .Values.kong.base }}
     recordTTL: 300
     recordType: CNAME
     targets:
-    - {{ $.Values.kong.ingressCname }}
-{{- end }}
+    - {{ .Values.kong.ingressCname }}
 {{- end }}
 {{- end }}

--- a/helm/microservices-demo-app/templates/kong/gateway.yaml
+++ b/helm/microservices-demo-app/templates/kong/gateway.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.frontend.create }}
+{{- if and .Values.kong.enabled .Values.kong.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  labels:
+    application.giantswarm.io/team: cabbage
+  annotations:
+    konghq.com/gatewayclass-unmanaged: "true"
+  name: kong
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  labels:
+    application.giantswarm.io/team: cabbage
+  annotations:
+    konghq.com/gateway-unmanaged: "kong/kong-app-kong-app-proxy"
+  name: kong
+  namespace: {{ .Release.Namespace }}
+spec:
+  gatewayClassName: kong
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: '*.{{ .Release.Namespace }}.{{ .Values.kong.base }}'                                                                                                                                                                                   
+    name: http                                                                                                                                                                                      
+    port: 80                                                                                                                                                                                        
+    protocol: HTTP
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: '*.{{ .Release.Namespace }}.{{ .Values.kong.base }}'
+    name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: kong-ingress-wildcard-tls
+      mode: Terminate
+{{- end }}
+{{- end }}

--- a/helm/microservices-demo-app/templates/kong/httproute.yaml
+++ b/helm/microservices-demo-app/templates/kong/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.frontend.create }}
+{{- if and .Values.httproute.enabled .Values.kong.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kong-{{ .Values.frontend.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kong
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    - "{{ .Values.kong.host }}.{{ .Release.Namespace }}.{{ .Values.kong.base }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.frontend.name }}
+          namespace: {{ .Release.Namespace }}
+          port: 80
+{{- end }}
+{{- end }}

--- a/helm/microservices-demo-app/values.schema.json
+++ b/helm/microservices-demo-app/values.schema.json
@@ -555,6 +555,14 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "gatewayAPI": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "host": {
                     "type": "string"
                 },

--- a/helm/microservices-demo-app/values.yaml
+++ b/helm/microservices-demo-app/values.yaml
@@ -33,6 +33,8 @@ ingress:
 kong:
   enabled: true
   number: 10
+  gatewayAPI:
+    enabled: true
   customCertificate:
     enabled: true
   annotations:


### PR DESCRIPTION
This PR updates the kong part of the helm chart so that it supports Gateway API. It also updates the envoy loadtesting kong values so that kong stops reconciling ingresses and only reconcile its own gateways.

The [follow-up PR](https://github.com/giantswarm/microservices-demo-app/pull/20) updates the test setup so that NGINX and Kong tests are run separately.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
