### PR TITLE
fix kong gateway api deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add "gateway api not enabled" condition for kong ingress deployment.
+
 ## [0.8.0] - 2026-06-02
 
 ### Changed

--- a/helm/microservices-demo-app/templates/kong/ingress.yaml
+++ b/helm/microservices-demo-app/templates/kong/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.frontend.create }}
-{{- if .Values.kong.enabled }}
+{{- if and .Values.kong.enabled (not .Values.kong.gatewayAPI.enabled) }}
 {{ range $i := until (.Values.kong.number | int) }}
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
This was making Envoy vs Kong performance test fail because the microservices-demo chart couldn't get deployed when using Kong and gateway api. It was failing with the following error message:
```
admission webhook "vingress.elbv2.k8s.aws" denied the request:
invalid ingress class: IngressClass.networking.k8s.io "kong" not found
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
